### PR TITLE
Update signing transaction method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Signing/Signing.ts
+++ b/src/Signing/Signing.ts
@@ -56,23 +56,27 @@ const signOrder:(web3: any, signingAccount: string, data: SigningData) => Promis
         }
         return web3.currentProvider?.send(
             {
-                method: "eth_signTypedData",
-                params: [signer, data],
+                method: "eth_signTypedData_v3",
+                params: [signer, JSON.stringify(data)],
                 from: signer,
             },
             async (err: any, result: any) => {
-                if (err) {
-                    reject(err)
+                if (err || result.error) {
+                    reject(err ?? result.error)
                 }
-                let parsedSig = result.result.substring(2)
-                const r: string = "0x" + parsedSig.substring(0, 64)
-                const s: string = "0x" + parsedSig.substring(64, 128)
-                const v: number = parseInt(parsedSig.substring(128, 130), 16) //130 hex = 65bytes
-                resolve({
-                    sigR: r,
-                    sigS: s,
-                    sigV: v
-                })
+                try {
+                    let parsedSig = result.result.substring(2)
+                    const r: string = "0x" + parsedSig.substring(0, 64)
+                    const s: string = "0x" + parsedSig.substring(64, 128)
+                    const v: number = parseInt(parsedSig.substring(128, 130), 16) //130 hex = 65bytes
+                    resolve({
+                        sigR: r,
+                        sigS: s,
+                        sigV: v
+                    })
+                } catch (error) {
+                    reject(error);
+                }
             }
         )
     })


### PR DESCRIPTION
### Motivation
- Client side was not liking the signTypedData method
- Metamask has 6 types of signing methods https://docs.metamask.io/guide/signing-data.html#a-brief-history
- Where signTypedData is deprecated over signTypedData_v3 which matches the current [EIP712 spec](https://eips.ethereum.org/EIPS/eip-712)

### Changes
- add a few error checks that were sliding under the radar
- change signing message to v3
- stringify params because it wanted them as strings