### PR TITLE
Add position account calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -163,23 +163,23 @@ export const calcTradeExposure: (
         let exposure = 0,
             sumOfWeights = 0,
             totalUnits = 0;
-        let deposit = quote * leverage; // total units of underlying
+        let buyingPower = quote * leverage; // total units of underlying
         for (const order of orders) {
             const amount = order.amount;
             const orderPrice = order.price;
             // remainding units of accounts quote use
-            const r = deposit - amount * orderPrice;
+            const r = buyingPower - amount * orderPrice;
             if (r >= 0) { // if it can eat the whole order
                 totalUnits += orderPrice * amount;
                 sumOfWeights += amount;
                 exposure += amount * orderPrice; // units of the assets
-                deposit -= amount * orderPrice; // subtract the remainder in units of underLying
+                buyingPower -= amount * orderPrice; // subtract the remainder in units of underLying
             } else { // eat a bit of the order nom nom
                 // if we get here the max amount we can is the remainder of deposit
-                if (deposit) {
-                    totalUnits += deposit * orderPrice;
-                    sumOfWeights += deposit;
-                    exposure += deposit / orderPrice;
+                if (buyingPower) {
+                    totalUnits += buyingPower * orderPrice;
+                    sumOfWeights += buyingPower;
+                    exposure += buyingPower / orderPrice;
                 }
                 break;
             }
@@ -190,7 +190,7 @@ export const calcTradeExposure: (
         const tradePrice = totalUnits ? totalUnits / sumOfWeights: expectedPrice;
         return {
             exposure: parseFloat(exposure.toFixed(10)),
-            slippage: 1 - expectedPrice/tradePrice,
+            slippage: Math.abs((expectedPrice - tradePrice) / expectedPrice),
             tradePrice: tradePrice
         };
     }

--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -1,0 +1,202 @@
+import { FlatOrder } from "../Types/accounting";
+
+const RYAN_6 = 6; // a number accredited to our good friend Ryan Garner
+const LIQUIDATION_GAS_COST = 25; // When gas price is 250 gwei and eth price is 1700, the liquidation gas cost is 25 USD.
+// const LIQUIDATION_PERCENTAGE = 0.075; // liquidation percentage of 7.5%
+
+/**
+ * Calculates the leverage multiplier the user currently has based on their position and a given price
+ */
+export const calcLeverage: (quote: number, base: number, price: number) => number = (quote, base, price) => {
+    return calcNotionalValue(base, price) / totalMargin(base, quote, price);
+};
+
+
+
+/**
+ * A function that returns the liquidation price for a given account.
+ *  This is the eligible liquidation price. 
+ *  Given BTC/USD the quote is USD and the base is BTC
+ * @param quote Amount of quote asset
+ * @param base Amount of base asset, this is considered the position of the account
+ * @param price The given price of the asset 
+ * @param maxLeverage The maximum leverage accounts can trade at. This is specific to the Tracer market
+ * @returns the price of the asset where the account is eligible for liquidation
+ */
+export const calcLiquidationPrice: (quote: number, base: number, price: number, maxLeverage: number) => number = (
+    quote,
+    base,
+    price,
+    maxLeverage,
+) => {
+    const borrowed = calcBorrowed(quote, base, price);
+    if (borrowed > 0 || base < 0) {
+        return base > 0 // case 1
+            ? (maxLeverage * (quote - RYAN_6 * LIQUIDATION_GAS_COST)) / (base - maxLeverage * base)
+            : 0 + base < 0 // case 2
+            ? (-1 * (quote * maxLeverage - RYAN_6 * LIQUIDATION_GAS_COST * maxLeverage)) / (maxLeverage * base + base)
+            : 0;
+    } else {
+        return 0;
+    }
+};
+
+/**
+ * A function that returns the proifitble liquidation price for a given account.
+ *  This is the profitible liquidation price, ie the price of the asset where a liquidator profits from
+ *  the liquidation.
+ *  Given BTC/USD the quote is USD and the base is BTC
+ * @param quote Amount of quote asset
+ * @param base Amount of base asset, this is considered the position of the account
+ * @param price The given price of the asset 
+ * @param maxLeverage The maximum leverage accounts can trade at. This is specific to the Tracer market
+ * @returns the price of the asset where it is profitible for a liquidator to liquidate the account
+ */
+export const calcProfitableLiquidationPrice: (
+    quote: number,
+    base: number,
+    price: number,
+    maxLeverage: number,
+) => number = (quote, base, price, maxLeverage) => {
+    const margin = totalMargin(base, quote, price);
+    const borrowed = calcBorrowed(quote, base, price);
+    if (borrowed > 0 || margin < 0) {
+        return quote > 0 // case 1
+            ? (maxLeverage * (base - (RYAN_6 * LIQUIDATION_GAS_COST - LIQUIDATION_GAS_COST))) /
+                  (quote - maxLeverage * quote)
+            : 0 + quote < 0 // case 2
+            ? -1 *
+              ((base * (maxLeverage - (RYAN_6 * LIQUIDATION_GAS_COST - LIQUIDATION_GAS_COST) * maxLeverage)) /
+                  (maxLeverage * quote + quote))
+            : 0;
+    } else {
+        return 0;
+    }
+};
+
+/**
+ * Calculates the amount borrowed by an accoun
+ *  Given BTC/USD the quote is USD and the base is BTC
+ * @param quote Amount of quote asset
+ * @param base Amount of base asset, this is considered the position of the account
+ * @param price The given price of the asset 
+ * @returns the amount borrowed by an account or 0 if the borrowed amount is negative
+ */
+export const calcBorrowed: (quote: number, base: number, price: number) => number = (quote, base, price) =>
+    Math.max(0, calcNotionalValue(base, price) - totalMargin(base, quote, price));
+
+/**
+ * Calculates the withdrawable amount of quote asset. This will put the account just above
+ * the eligible for liquidation price and is not a good position to be in.
+ *  Given BTC/USD the quote is USD and the base is BTC
+ * @param quote Amount of quote asset
+ * @param base Amount of base asset, this is considered the position of the account
+ * @param price The given price of the asset 
+ * @param maxLeverage The maximum leverage accounts can trade at. This is specific to the Tracer market
+ * @returns the withdrawable amount of quote asset.
+ */
+export const calcWithdrawable: (quote: number, base: number, price: number, maxLeverage: number) => number = (
+    quote,
+    base,
+    price,
+    maxLeverage,
+) => {
+    return totalMargin(base, quote, price) - (base !== 0 ? LIQUIDATION_GAS_COST * RYAN_6 + calcNotionalValue(base, price) / maxLeverage : 0);
+};
+
+/**
+ * Calculates the notional value of the position
+ * @param base Amount of base asset, this is considered the position of the account
+ * @param price The given price of the asset 
+ * @returns the notional value of the position
+ */
+export const calcNotionalValue: (base: number, price: number) => number = (base, price) => {
+    return Math.abs(base) * price;
+};
+
+/**
+ * Calculates the minimum margin required for a given position and price. This is closely related to the liquidationPrice
+ * @param quote Amount of quote asset
+ * @param base Amount of base asset, this is considered the position of the account
+ * @param price The given price of the asset 
+ * @returns the minimum margin required for an accounts outstanding position. 
+ *  An account with minimumMargin are in a position close to liquidation.
+ */
+export const calcMinimumMargin: (quote: number, base: number, price: number, maxLeverage: number) => number = (
+    quote,
+    base,
+    price,
+    maxLeverage,
+) => {
+    const margin = totalMargin(base, quote, price);
+    if (margin > 0 || base < 0) {
+        return LIQUIDATION_GAS_COST * RYAN_6 + calcNotionalValue(base, price) / maxLeverage;
+    } else {
+        return 0;
+    }
+};
+
+/**
+ * Total margin of an account given a position
+ *  aka equity, the amount owned by the user if they cashed out at the given price
+ * @param quote Amount of quote asset
+ * @param base Amount of base asset, this is considered the position of the account
+ * @param price The given price of the asset 
+ * @returns the total margin of an account
+ */
+export const totalMargin: (base: number, quote: number, price: number) => number = (base, quote, price) =>
+    quote + base * price;
+
+/**
+ * Calculates a theoretical market exposure if it took all the 'best' orders it could
+ *  Returns this exposure and the orders that allow it to gain this exposure
+ * @param quote Amount of quote asset
+ * @param leverage leverage of the trade this could be passed in as quote leverage * quote
+ */
+export const calcTradeExposure: (
+    quote: number,
+    leverage: number,
+    orders: FlatOrder[],
+) => { exposure: number, slippage: number, tradePrice: number } = (quote, leverage, orders) => {
+    if (orders.length) {
+        // weighted average of the price, where the weights are the amounts at each price
+        let exposure = 0,
+            sumOfWeights = 0,
+            totalUnits = 0;
+        let deposit = quote * leverage; // total units of underlying
+        for (const order of orders) {
+            const amount = order.amount;
+            const orderPrice = order.price;
+            // remainding units of accounts quote use
+            const r = deposit - amount * orderPrice;
+            if (r >= 0) { // if it can eat the whole order
+                totalUnits += orderPrice * amount;
+                sumOfWeights += amount;
+                exposure += amount * orderPrice; // units of the assets
+                deposit -= amount * orderPrice; // subtract the remainder in units of underLying
+            } else { // eat a bit of the order nom nom
+                // if we get here the max amount we can is the remainder of deposit
+                if (deposit) {
+                    totalUnits += deposit * orderPrice;
+                    sumOfWeights += deposit;
+                    exposure += deposit / orderPrice;
+                }
+                break;
+            }
+        }
+        
+        const expectedPrice = orders[0].price;
+        // this is a weighted average of the prices and how much was taken at each price
+        const tradePrice = totalUnits ? totalUnits / sumOfWeights: expectedPrice;
+        return {
+            exposure: parseFloat(exposure.toFixed(10)),
+            slippage: 1 - expectedPrice/tradePrice,
+            tradePrice: tradePrice
+        };
+    }
+    return {
+        exposure: 0,
+        slippage: 0,
+        tradePrice: 0,
+    };
+};

--- a/src/Types/accounting.ts
+++ b/src/Types/accounting.ts
@@ -1,0 +1,6 @@
+
+
+export interface FlatOrder {
+    price: number,
+    amount: number,
+}

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import { calcTradeExposure } from "../src/Accounting"
+
+const orders = [
+    {
+        amount: 10,
+        price: 1
+    }, 
+    {
+        amount: 20,
+        price: 1.1
+    }, 
+    {
+        amount: 30,
+        price: 1.2
+    }
+]
+
+describe('calcTradeExposure', () => {
+  it('no orders', () => {
+    const { exposure, slippage, tradePrice } = calcTradeExposure(0, 1, [])
+    expect(exposure).to.equal(0);
+    expect(slippage).to.equal(0);
+    expect(tradePrice).to.equal(0);
+  });
+
+  it('no margin, no exposure', () => {
+    const { exposure, slippage, tradePrice } = calcTradeExposure(0, 1, orders)
+    expect(exposure).to.equal(0);
+    expect(slippage).to.equal(0);
+    expect(tradePrice).to.equal(1);
+  });
+  it('quote <= order[0].notional', () => {
+    const { exposure, slippage, tradePrice } = calcTradeExposure(10, 1, orders)
+    expect(exposure).to.equal(10);
+    expect(slippage).to.equal(0)
+    expect(tradePrice).to.equal(1);
+  });
+  it('order[0].notional <= quote <= order[1].notional', () => {
+    const { exposure, slippage, tradePrice } = calcTradeExposure(20, 1, orders)
+    expect(exposure).to.equal(19.0909090909);
+    // actual paid price === 1.05
+    expect(slippage).to.equal(0.04761904761904767)
+    expect(tradePrice).to.equal(1.05);
+  });
+  it('takes all orders', () => {
+    // here we are taking 10 orders at 1, 20 at 1.1 and 30 at 1.2
+    // round 1 60 - 10 (at $1)
+        // 68 - 10 = 58 left over
+    // round 2 20 (at $1.1)
+        // 58 - (20 * 1.1) = 36 left over
+    // round 3 30 at ($1.2)
+        // 36 - (30 * 1.2) - 0 left over
+    // price should be (10 * 1 + 20 * 1.1 + 30 * 1.2) / 60
+    // trade price at 1.133333333
+    const { exposure, slippage, tradePrice } = calcTradeExposure(68, 1, orders)
+    expect(exposure).to.equal(68)
+    expect(slippage).to.equal(0.11764705882352944)
+    // 10 0's
+    expect(tradePrice).to.equal(1.1333333333333333);
+  });
+  it('takes all orders and beyond', () => {
+    // should be same as above
+    const { exposure, slippage, tradePrice } = calcTradeExposure(300, 1, orders)
+    expect(exposure).to.equal(68)
+    expect(slippage).to.equal(0.11764705882352944)
+    // 10 0's
+    expect(tradePrice).to.equal(1.1333333333333333);
+  });
+  it('takes all orders with leverage', () => {
+    // should be same as above
+    const { exposure, slippage, tradePrice } = calcTradeExposure(34, 2, orders)
+    expect(exposure).to.equal(68)
+    expect(slippage).to.equal(0.11764705882352944)
+    // 10 0's
+    expect(tradePrice).to.equal(1.1333333333333333);
+  });
+});

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -35,12 +35,13 @@ describe('calcTradeExposure', () => {
     expect(exposure).to.equal(10);
     expect(slippage).to.equal(0)
     expect(tradePrice).to.equal(1);
+
   });
   it('order[0].notional <= quote <= order[1].notional', () => {
     const { exposure, slippage, tradePrice } = calcTradeExposure(20, 1, orders)
     expect(exposure).to.equal(19.0909090909);
     // actual paid price === 1.05
-    expect(slippage).to.equal(0.04761904761904767)
+    expect(slippage).to.approximately(0.05, 0.00001)
     expect(tradePrice).to.equal(1.05);
   });
   it('takes all orders', () => {
@@ -55,7 +56,7 @@ describe('calcTradeExposure', () => {
     // trade price at 1.133333333
     const { exposure, slippage, tradePrice } = calcTradeExposure(68, 1, orders)
     expect(exposure).to.equal(68)
-    expect(slippage).to.equal(0.11764705882352944)
+    expect(slippage).to.approximately(0.133333, 0.00001)
     // 10 0's
     expect(tradePrice).to.equal(1.1333333333333333);
   });
@@ -63,7 +64,7 @@ describe('calcTradeExposure', () => {
     // should be same as above
     const { exposure, slippage, tradePrice } = calcTradeExposure(300, 1, orders)
     expect(exposure).to.equal(68)
-    expect(slippage).to.equal(0.11764705882352944)
+    expect(slippage).to.approximately(0.133333, 0.00001)
     // 10 0's
     expect(tradePrice).to.equal(1.1333333333333333);
   });
@@ -71,7 +72,7 @@ describe('calcTradeExposure', () => {
     // should be same as above
     const { exposure, slippage, tradePrice } = calcTradeExposure(34, 2, orders)
     expect(exposure).to.equal(68)
-    expect(slippage).to.equal(0.11764705882352944)
+    expect(slippage).to.approximately(0.133333, 0.00001)
     // 10 0's
     expect(tradePrice).to.equal(1.1333333333333333);
   });


### PR DESCRIPTION
### Motivation
- Moving some of the position accounting calculations and other calculations off the frontend to clean it up a little
- Also provides a central store of the calculations that can be referenced in the future by external parties

### Changes
- Add the position accounting calculations
- Simplify exposure calculation
- Add some tests