### PR TITLE
Lmdevs 278 add accounting tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -148,7 +148,7 @@ export const calcMinimumMargin: (quote: number, base: number, price: number, max
  * @returns the total margin of an account
  */
 export const calcTotalMargin: (quote: number, base: number, price: number) => number = (quote, base, price) =>
-    quote + base * price;
+    (quote + base * price) ?? 0; // return 0 if something goes wrong
 
 /**
  * Calculates a theoretical market exposure if it took all the 'best' orders it could

--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -6,8 +6,11 @@ const LIQUIDATION_GAS_COST = 25; // When gas price is 250 gwei and eth price is 
 
 /**
  * Calculates the leverage multiplier the user currently has based on their position and a given price
+ * @returns the leverage of the user at a given position or -1 if the position is invalid this represents infinite leverage
  */
 export const calcLeverage: (quote: number, base: number, price: number) => number = (quote, base, price) => {
+    const margin = calcTotalMargin(quote, base, price);
+    if (margin <= 0) return -1
     return calcNotionalValue(base, price) / calcTotalMargin(quote, base, price);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './Signing';
 export * from './OME';
 export * from './Serialisation';
 export * from './Types/types';
+export * from './Accounting';

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -1,5 +1,25 @@
 import { expect } from 'chai';
-import { calcTradeExposure } from "../src/Accounting"
+import { 
+  calcTradeExposure,
+  calcBorrowed,
+  calcTotalMargin,
+  calcMinimumMargin,
+  calcWithdrawable,
+  calcNotionalValue,
+  calcLeverage,
+  calcLiquidationPrice,
+  calcProfitableLiquidationPrice,
+} from "../src/Accounting"
+
+// Deposit 200 at $100, short 10 units
+const position1 = {
+  quote: 1200, base: -10, price: 100, maxLeverage: 50
+}
+
+// 25 leverage
+const position2 = {
+  quote: -9600, base: 100, price: 100, maxLeverage: 50
+}
 
 const orders = [
     {
@@ -77,3 +97,59 @@ describe('calcTradeExposure', () => {
     expect(tradePrice).to.equal(1.1333333333333333);
   });
 });
+
+describe("Testing margin", () => {
+  it('Basic Positions', () => {
+    expect(calcTotalMargin(position1.quote, position1.base, position1.price), 'Position 1').to.equal(200)
+    expect(calcTotalMargin(position2.quote, position2.base, position2.price), 'Position 2').to.equal(400)
+  })
+})
+
+describe("Testing calcNotional", () => {
+  it('Basic Position', () => {
+    expect(calcNotionalValue(position1.base, position1.price), "Position 1").to.equal(1000)
+    expect(calcNotionalValue(position2.base, position2.price), 'Position 2').to.equal(10000)
+  })
+})
+
+describe("Testing Minimum margin", () => {
+  it('Basic Positions', () => {
+    expect(calcMinimumMargin(position1.quote, position1.base, position1.price, position1.maxLeverage), 'Position 1').to.equal(170)
+    expect(calcMinimumMargin(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.equal(350)
+  })
+})
+
+describe("Testing calcBorrowed", () => {
+  it('Basic Positions', () => {
+    expect(calcBorrowed(position1.quote, position1.base, position1.price), 'Position 1').to.equal(800)
+    expect(calcBorrowed(position2.quote, position2.base, position2.price), 'Position 2').to.equal(9600)
+  })
+})
+
+describe("Testing calcLeverage", () => {
+  it('Basic Positions', () => {
+    expect(calcLeverage(position1.quote, position1.base, position1.price), 'Position 1').to.equal(5)
+    expect(calcLeverage(position2.quote, position2.base, position2.price), 'Position 2').to.equal(25)
+  })
+})
+
+describe("Testing liquidationPrice", () => {
+  it('Basic Positions', () => {
+    expect(calcLiquidationPrice(position1.quote, position1.base, position1.price, position1.maxLeverage), "Position 1").to.approximately(102.941, 0.001)
+    expect(calcLiquidationPrice(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.approximately(99.490, 0.001)
+  })
+})
+
+describe("Testing profitableForLiquidationPrice", () => {
+  it('Basic Positions', () => {
+    expect(calcProfitableLiquidationPrice(position1.quote, position1.base, position1.price, position1.maxLeverage), "Position 1").to.approximately(105.392, 0.001)
+    expect(calcProfitableLiquidationPrice(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.approximately(99.235, 0.001)
+  })
+})
+
+describe('Testing Withdrawable', () => {
+  it('Basic Positions', () => {
+    expect(calcWithdrawable(position1.quote, position1.base, position1.price, position1.maxLeverage), 'Position 1').to.equal(30)
+    expect(calcWithdrawable(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.equal(50)
+  })
+})

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -11,14 +11,27 @@ import {
   calcProfitableLiquidationPrice,
 } from "../src/Accounting"
 
+
+// Basic positions
+// The user holds a position not in liquidation
 // Deposit 200 at $100, short 10 units
 const position1 = {
   quote: 1200, base: -10, price: 100, maxLeverage: 50
 }
-
 // 25 leverage
 const position2 = {
   quote: -9600, base: 100, price: 100, maxLeverage: 50
+}
+// Invalid positions
+// The user holds a position and can be liquidated
+// no margin
+const invalid1 = {
+  quote: -1000, base: 10, price: 100, maxLeverage: 50
+}
+// not enough margin due to liquidation gas prices
+// is actually a valid position otherwise
+const invalid2 = {
+  quote: 2050, base: -20, price: 100, maxLeverage: 50
 }
 
 const orders = [
@@ -103,12 +116,20 @@ describe("Testing margin", () => {
     expect(calcTotalMargin(position1.quote, position1.base, position1.price), 'Position 1').to.equal(200)
     expect(calcTotalMargin(position2.quote, position2.base, position2.price), 'Position 2').to.equal(400)
   })
+  it('Invalid Positions', () => {
+    expect(calcTotalMargin(invalid1.quote, invalid1.base, invalid1.price), 'Invalid 1').to.equal(0)
+    expect(calcTotalMargin(invalid2.quote, invalid2.base, invalid2.price), 'Invalid 2').to.equal(50)
+  })
 })
 
 describe("Testing calcNotional", () => {
   it('Basic Position', () => {
     expect(calcNotionalValue(position1.base, position1.price), "Position 1").to.equal(1000)
     expect(calcNotionalValue(position2.base, position2.price), 'Position 2').to.equal(10000)
+  })
+  it('Invalid Positions', () => {
+    expect(calcNotionalValue(invalid1.base, invalid1.price), 'Invalid 1').to.equal(1000)
+    expect(calcNotionalValue(invalid2.base, invalid2.price), 'Invalid 2').to.equal(2000)
   })
 })
 
@@ -117,12 +138,20 @@ describe("Testing Minimum margin", () => {
     expect(calcMinimumMargin(position1.quote, position1.base, position1.price, position1.maxLeverage), 'Position 1').to.equal(170)
     expect(calcMinimumMargin(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.equal(350)
   })
+  it('Invalid Positions', () => {
+    expect(calcMinimumMargin(invalid1.quote, invalid1.base, invalid1.price, invalid1.maxLeverage), 'Invalid 1').to.equal(170)
+    expect(calcMinimumMargin(invalid2.quote, invalid2.base, invalid2.price, invalid2.maxLeverage), 'Invalid 2').to.equal(190)
+  })
 })
 
 describe("Testing calcBorrowed", () => {
   it('Basic Positions', () => {
     expect(calcBorrowed(position1.quote, position1.base, position1.price), 'Position 1').to.equal(800)
     expect(calcBorrowed(position2.quote, position2.base, position2.price), 'Position 2').to.equal(9600)
+  })
+  it('Invalid Positions', () => {
+    expect(calcBorrowed(invalid1.quote, invalid1.base, invalid1.price), 'Invalid 1').to.equal(1000)
+    expect(calcBorrowed(invalid2.quote, invalid2.base, invalid2.price), 'Invalid 2').to.equal(1950)
   })
 })
 
@@ -131,12 +160,21 @@ describe("Testing calcLeverage", () => {
     expect(calcLeverage(position1.quote, position1.base, position1.price), 'Position 1').to.equal(5)
     expect(calcLeverage(position2.quote, position2.base, position2.price), 'Position 2').to.equal(25)
   })
+  it('Invalid Positions', () => {
+    expect(calcLeverage(invalid1.quote, invalid1.base, invalid1.price), 'Invalid 1').to.equal(-1)
+    expect(calcLeverage(invalid2.quote, invalid2.base, invalid2.price), 'Invalid 2').to.equal(40)
+  })
 })
 
 describe("Testing liquidationPrice", () => {
   it('Basic Positions', () => {
     expect(calcLiquidationPrice(position1.quote, position1.base, position1.price, position1.maxLeverage), "Position 1").to.approximately(102.941, 0.001)
     expect(calcLiquidationPrice(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.approximately(99.490, 0.001)
+  })
+  it('Invalid Positions', () => {
+    // since this is long they are already in liquidation
+    expect(calcLiquidationPrice(invalid1.quote, invalid1.base, invalid1.price, invalid1.maxLeverage), 'Invalid 1').to.approximately(117.347, 0.001)
+    expect(calcLiquidationPrice(invalid2.quote, invalid2.base, invalid2.price, invalid2.maxLeverage), 'Invalid 2').to.approximately(93.137, 0.001)
   })
 })
 
@@ -145,11 +183,21 @@ describe("Testing profitableForLiquidationPrice", () => {
     expect(calcProfitableLiquidationPrice(position1.quote, position1.base, position1.price, position1.maxLeverage), "Position 1").to.approximately(105.392, 0.001)
     expect(calcProfitableLiquidationPrice(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.approximately(99.235, 0.001)
   })
+  it('Invalid Positions', () => {
+    // since this is long they are already in liquidation
+    expect(calcProfitableLiquidationPrice(invalid1.quote, invalid1.base, invalid1.price, invalid1.maxLeverage), 'Invalid 1').to.approximately(114.796, 0.001)
+    expect(calcProfitableLiquidationPrice(invalid2.quote, invalid2.base, invalid2.price, invalid2.maxLeverage), 'Invalid 2').to.approximately(94.363, 0.001)
+  })
 })
 
 describe('Testing Withdrawable', () => {
   it('Basic Positions', () => {
     expect(calcWithdrawable(position1.quote, position1.base, position1.price, position1.maxLeverage), 'Position 1').to.equal(30)
     expect(calcWithdrawable(position2.quote, position2.base, position2.price, position2.maxLeverage), 'Position 2').to.equal(50)
+  })
+  it('Invalid Positions', () => {
+    // they cannot withdraw anything
+    expect(calcWithdrawable(invalid1.quote, invalid1.base, invalid1.price, invalid1.maxLeverage), 'Invalid 1').to.equal(-170)
+    expect(calcWithdrawable(invalid2.quote, invalid2.base, invalid2.price, invalid2.maxLeverage), 'Invalid 2').to.equal(-140)
   })
 })


### PR DESCRIPTION
### Motivation
- Add tests for position account functions to verify the information being displayed is correct

### Changes
- Add basic positions tests, these are standard short and long positions
- Add underwater position tests, these are accounts that can be liquidated
- Updated calcProfitableLiquidationPrice to match base and quote changes
- Update calcBorrowed to match base and quote changes
