### PR TITLE
add signTypedData v4 method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Signing/Signing.ts
+++ b/src/Signing/Signing.ts
@@ -169,9 +169,21 @@ const signOrdersV3: (
     return _signOrders(web3, orders, traderAddress, "eth_signTypedData_v3", chainId);
 };
 
+const signOrdersV4: (
+    web3: any,
+    orders: OrderData[],
+    traderAddress: string,
+    chainId?: number
+) => Promise<
+    Promise<{ order: OrderData; sigR: string; sigS: string; sigV: number }>[]
+> = async (web3, orders, traderAddress, chainId) => {
+    return _signOrders(web3, orders, traderAddress, "eth_signTypedData_v4", chainId);
+};
+
 export {
     signOrders,
     signOrdersV3,
+    signOrdersV4,
     signOrder,
     generateDomainData,
     domain,

--- a/src/Signing/Signing.ts
+++ b/src/Signing/Signing.ts
@@ -69,7 +69,7 @@ const signOrder: (
                 params: [
                     signer,
                     // sign typed data v3 expects stringified data
-                    signMethod === "eth_signTypedData_v3"
+                    signMethod === "eth_signTypedData_v3" || signMethod === "eth_signTypedData_v4"
                         ? JSON.stringify(data)
                         : data,
                 ],


### PR DESCRIPTION
# Motivation
Metamask supports signTypedData v4 and ganache uses this as the default (via `eth_signTypedData`). This PR adds support for explicit v4 signing calls

# Changes
- add signOrdersV4 method