### PR TITLE
Signature Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Supported are the following functions
 - submitOrder: submits an EIP712 compliant signed order to the OME.
 
 ## Signing
-This package adds utility functionality for signing orders via the EIP712 [specification](https://eips.ethereum.org/EIPS/eip-712)
+This package adds utility functionality for signing orders via the EIP712 [specification](https://eips.ethereum.org/EIPS/eip-712). The contracts currently utilise V4 of the EIP712 spec. Both `eth_signTypedData` and `eth_signTypedData_v4` calls are supported due to how some wallet implementations handle this EIP.
 
 Supported are the following functions
-- signOrder: sign a single instance of an order via a local Ethereum node using the eth_signTypedData RPC call
-- signOrders: sign multiple orders are once.
+- signOrders: sign multiple orders via a local Ethereum node using the eth_signTypedData RPC call
+- signOrdersV4: sign multiple orders via a local Ethereum node using the eth_signTypedData_v4 RPC call
+- verifySignature: verifies a provided order was signed by a specific signer.
+- generateDomainData: generates EIP712 compliant domain data for a given trader address on a given network.
 
 ## Serialisation
 This package adds utility functionality for serialising orders between the contracts and the OME

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@types/node": "^14.14.37",
     "bignumber.js": "^9.0.1",
     "chai": "^4.3.4",
+    "eth-sig-util": "^3.0.1",
+    "ethers": "^5.3.0",
     "ganache-cli": "^6.12.2",
     "node-fetch": "^2.6.1",
     "tslib": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Signing/Signing.ts
+++ b/src/Signing/Signing.ts
@@ -168,23 +168,6 @@ const signOrders: (
     );
 };
 
-const signOrdersV3: (
-    web3: any,
-    orders: OrderData[],
-    traderAddress: string,
-    chainId?: number
-) => Promise<
-    Promise<{ order: OrderData; sigR: string; sigS: string; sigV: number }>[]
-> = async (web3, orders, traderAddress, chainId) => {
-    return _signOrders(
-        web3,
-        orders,
-        traderAddress,
-        "eth_signTypedData_v3",
-        chainId
-    );
-};
-
 const signOrdersV4: (
     web3: any,
     orders: OrderData[],
@@ -202,7 +185,7 @@ const signOrdersV4: (
     );
 };
 
-const verifySignatures: (
+const verifySignature: (
     order: OrderData,
     traderAddress: string,
     sig: string,
@@ -239,11 +222,10 @@ const verifySignatures: (
 
 export {
     signOrders,
-    signOrdersV3,
     signOrdersV4,
     signOrder,
     generateDomainData,
     domain,
     orderType,
-    verifySignatures
+    verifySignature
 };

--- a/test/signingTests.ts
+++ b/test/signingTests.ts
@@ -1,9 +1,40 @@
 import { expect } from 'chai';
-import { generateDomainData } from "../src/Signing"
+import { generateDomainData, verifySignatures } from "../src/Signing"
+
+// todo would be good to test this using 
+// our sign methods too...
+let correctlySignedData = {
+  order: {
+    maker: '0xfb59B91646cd0890F3E5343384FEb746989B66C7',
+    market: '0x100b427A173fA3e66759449B4Cf63818Bedb9F47',
+    price: '1000000000000000000',
+    amount: '1000000000000000000',
+    side: 1,
+    expires: 1918373212,
+    created: 0
+  },
+  trader: "0xE7Cd937E73a750B9fe91100BD47b4c6EbBf50dD4",
+  sig: "0x1fc3a9d92e2eb86967c077253dc2f5623be574c675c9d97f14c478c8a339028a4b01625c8f6c415d86f4044bfaaf8ada0d0310dc8c1fce1c097483ebc2f40d2b1c"
+}
+
 
 describe('generateDomainData', () => {
   it('should set the correct network', () => {
     const sampleData = generateDomainData("0xCaADD6982a36e3f5DDD271894EE2eDd4c10ef4Fd", 69)
     expect(sampleData.chainId).to.equal(69);
   });
+});
+
+describe('verifySignature', () => {
+  it('returns true for correctly signed data', () => {
+    const result = verifySignatures(correctlySignedData.order, correctlySignedData.trader,
+      correctlySignedData.sig, correctlySignedData.order.maker, 42)
+    expect(result).to.equal(true)
+  });
+
+  it('returns false for incorrectly signed data', () => {
+    const result = verifySignatures(correctlySignedData.order, correctlySignedData.trader,
+      correctlySignedData.sig, correctlySignedData.order.maker, 1337)
+    expect(result).to.equal(false)
+  })
 });

--- a/test/signingTests.ts
+++ b/test/signingTests.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { generateDomainData, verifySignatures } from "../src/Signing"
+import { generateDomainData, verifySignature } from "../src/Signing"
 
 // todo would be good to test this using 
 // our sign methods too...
@@ -27,13 +27,13 @@ describe('generateDomainData', () => {
 
 describe('verifySignature', () => {
   it('returns true for correctly signed data', () => {
-    const result = verifySignatures(correctlySignedData.order, correctlySignedData.trader,
+    const result = verifySignature(correctlySignedData.order, correctlySignedData.trader,
       correctlySignedData.sig, correctlySignedData.order.maker, 42)
     expect(result).to.equal(true)
   });
 
   it('returns false for incorrectly signed data', () => {
-    const result = verifySignatures(correctlySignedData.order, correctlySignedData.trader,
+    const result = verifySignature(correctlySignedData.order, correctlySignedData.trader,
       correctlySignedData.sig, correctlySignedData.order.maker, 1337)
     expect(result).to.equal(false)
   })


### PR DESCRIPTION
# Motivation
The executioner needs to provide a validation endpoint for the OME to submit signed orders to and find out if they are correctly signed.

# Changes
- introduces a `verifySignature` function
- adds ethers
- adds eth-sig-util