### PR TITLE
Alter signed data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Serialisation/Serialisation.ts
+++ b/src/Serialisation/Serialisation.ts
@@ -15,7 +15,7 @@ const orderToOMEOrder:(web3: any, signedOrder: SignedOrderData) => OMEOrder = (w
         amount: signedOrder.order.amount,
         expiration: signedOrder.order.expires,
         created: signedOrder.order.created,
-        signed_data: web3.utils.hexToBytes("0x" + signedOrder.sigR.substring(2) + signedOrder.sigS.substring(2) + signedOrder.sigV.toString(16)),
+        signed_data: "0x" + signedOrder.sigR.substring(2) + signedOrder.sigS.substring(2) + signedOrder.sigV.toString(16),
     } as OMEOrder
 }
 


### PR DESCRIPTION
# Motivation
The OME expects its signed data as a hex string and not a byte array now.

# Changes
- alter `orderToOmeOrder` function to parse data correctly