### PR TITLE
Margin utils

### DIFF
--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -348,10 +348,9 @@ export const calcUnrealised: (
 
 /**
  * Given a users position and a trade, returns the users new position after the trade has been applied
- * @param base position
- * @param price current price
+ * @param position the users current position
+ * @param trade the trade to be performed
  * @param feeRate fee rate of the market eg. 0.02 for 2%
- * @requires the trade amount to be denoted in a token with 18 decimal places
  * @returns the users new position
  */
 export const calcPositionAfterTrade: (
@@ -382,9 +381,9 @@ export const calcPositionAfterTrade: (
 
 /**
  * Gets the fee of the trade given the amount, execution price and feeRate
- * @param amount
- * @param executionPrice
- * @param feeRate
+ * @param amount amount of base asset to trade
+ * @param executionPrice price at which to perform trade
+ * @param feeRate fee rate of the market
  * @returns the total fee to perform the trade
  */
 export const calcFee: (

--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -367,10 +367,10 @@ export const calcPositionAfterTrade: (
     // long
     if(!trade.position) {
         newBase = position.base.plus(trade.amount);
-        newQuote = position.quote.minus(quoteChange.plus(fee));
+        newQuote = position.quote.minus(quoteChange).minus(fee);
     } else {
         newBase = position.base.minus(trade.amount);
-        newQuote = position.quote.plus(quoteChange.minus(fee));
+        newQuote = position.quote.plus(quoteChange).minus(fee);
     }
 
     return {

--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -1,4 +1,4 @@
-import { FlatOrder, FlatOrderWithSide, Position } from "../Types/accounting";
+import { FlatOrder, FlatOrderWithSide, Balance } from "../Types/accounting";
 import { BigNumber } from 'bignumber.js';
 
 export const RYAN_6 = new BigNumber(6); // a number accredited to our good friend Ryan Garner
@@ -348,16 +348,16 @@ export const calcUnrealised: (
 
 /**
  * Given a users position and a trade, returns the users new position after the trade has been applied
- * @param position the users current position
+ * @param balance the users current position
  * @param trade the trade to be performed
  * @param feeRate fee rate of the market eg. 0.02 for 2%
  * @returns the users new position
  */
 export const calcPositionAfterTrade: (
-    position: Position,
+    balance: Balance,
     trade: FlatOrderWithSide,
     feeRate: BigNumber
-) => Position = (position, trade, feeRate) => {
+) => Balance = (balance, trade, feeRate) => {
     const quoteChange = trade.amount.times(trade.price);
     const fee = calcFee(trade.amount, trade.price, feeRate);
 
@@ -366,11 +366,11 @@ export const calcPositionAfterTrade: (
 
     // long
     if(!trade.position) {
-        newBase = position.base.plus(trade.amount);
-        newQuote = position.quote.minus(quoteChange).minus(fee);
+        newBase = balance.base.plus(trade.amount);
+        newQuote = balance.quote.minus(quoteChange).minus(fee);
     } else {
-        newBase = position.base.minus(trade.amount);
-        newQuote = position.quote.plus(quoteChange).minus(fee);
+        newBase = balance.base.minus(trade.amount);
+        newQuote = balance.quote.plus(quoteChange).minus(fee);
     }
 
     return {

--- a/src/Types/accounting.ts
+++ b/src/Types/accounting.ts
@@ -9,7 +9,7 @@ export type FlatOrder = {
 // position is false if long
 export type FlatOrderWithSide = FlatOrder & { position: boolean }
 
-export type Position = {
+export type Balance = {
     quote: BigNumber,
     base: BigNumber
 }

--- a/src/Types/accounting.ts
+++ b/src/Types/accounting.ts
@@ -8,3 +8,8 @@ export type FlatOrder = {
 
 // position is false if long
 export type FlatOrderWithSide = FlatOrder & { position: boolean }
+
+export type Position = {
+    quote: BigNumber,
+    base: BigNumber
+}

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -5,7 +5,7 @@ var { expect } = chai;
 chai.use(require('chai-bignumber')());
 
 
-import { 
+import {
   calcTradeExposureFromQuoteAndLeverage,
   calcBorrowed,
   calcTotalMargin,
@@ -14,6 +14,7 @@ import {
   calcNotionalValue,
   calcLeverage,
   calcUnrealised,
+  calcPositionAfterTrade,
   // calcLiquidationPrice,
   // calcProfitableLiquidationPrice,
 } from "../src/Accounting"
@@ -46,11 +47,11 @@ const orders = [
     {
         amount: new BigNumber(10),
         price: new BigNumber(1)
-    }, 
+    },
     {
         amount: new BigNumber(20),
         price: new BigNumber(1.1)
-    }, 
+    },
     {
         amount: new BigNumber(30),
         price: new BigNumber(1.2)
@@ -62,39 +63,39 @@ const noShorts = [
         amount: new BigNumber(10),
         price: new BigNumber(100),
         position: false
-    }, 
+    },
     {
         amount: new BigNumber(10),
         price: new BigNumber(110),
         position: false
-    }, 
+    },
 ]
 const pnlOrders  = [
     {
         amount: new BigNumber(10),
         price: new BigNumber(100),
         position: false
-    }, 
+    },
     {
         amount: new BigNumber(10),
         price: new BigNumber(110),
         position: false
-    }, 
+    },
     {
         amount: new BigNumber(20),
         price: new BigNumber(120),
         position: false
-    }, 
+    },
     {
         amount: new BigNumber(10),
         price: new BigNumber(100),
-        position: true 
-    }, 
+        position: true
+    },
     {
         amount: new BigNumber(10),
         price: new BigNumber(110),
-        position: true 
-    }, 
+        position: true
+    },
     {
         amount: new BigNumber(20),
         price: new BigNumber(120),
@@ -262,7 +263,7 @@ describe.skip('Testing CalcUnrealised', () => {
     let short = long.negated()
     // no base
     expect(calcUnrealised(new BigNumber(0), position1.price, pnlOrders), 'Short 10 units').to.be.bignumber.equal(0)
-    // no shorts 
+    // no shorts
     expect(calcUnrealised(short, position1.price, noShorts), 'No short orders').to.be.bignumber.equal(0)
     // avgPrice should be 100
     expect(calcUnrealised(short, position1.price, pnlOrders), 'Short 10 units').to.be.bignumber.equal(0)
@@ -287,5 +288,37 @@ describe.skip('Testing CalcUnrealised', () => {
     expect(calcUnrealised(long.times(3), position1.price, pnlOrders), 'Long 30 units').to.be.bignumber.equal(-300)
     expect(calcUnrealised(long.times(3), new BigNumber(110), pnlOrders), 'Long 30 units, Price 110').to.be.bignumber.equal(0)
     expect(calcUnrealised(long.times(3), new BigNumber(90), pnlOrders), 'Long 30 units, Price 90').to.be.bignumber.equal(-600)
+  })
+})
+
+describe('calcPositionAfterTrade', () => {
+  it('Calculates applying a long position', () => {
+
+    const newPosition = calcPositionAfterTrade({
+      quote: new BigNumber('10000'),
+      base: new BigNumber('1')
+    }, {
+      amount: new BigNumber('1'),
+      price: new BigNumber('5000'),
+      position: false // long
+    }, new BigNumber('0.02')) // 2%
+
+    expect(newPosition.base).to.eql(new BigNumber('2'))
+    expect(newPosition.quote).to.eql(new BigNumber('4900')) // 2% fee on $5000 = $100
+  })
+
+  it('Calculates applying a short position', () => {
+
+    const newPosition = calcPositionAfterTrade({
+      quote: new BigNumber('10000'),
+      base: new BigNumber('1')
+    }, {
+      amount: new BigNumber('1'),
+      price: new BigNumber('5000'),
+      position: false // long
+    }, new BigNumber('0.02')) // 2%
+
+    expect(newPosition.base).to.eql(new BigNumber('2'))
+    expect(newPosition.quote).to.eql(new BigNumber('4900')) // 2% fee on $5000 = $100
   })
 })

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -315,10 +315,10 @@ describe('calcPositionAfterTrade', () => {
     }, {
       amount: new BigNumber('1'),
       price: new BigNumber('5000'),
-      position: false // long
+      position: true // short
     }, new BigNumber('0.02')) // 2%
 
-    expect(newPosition.base).to.eql(new BigNumber('2'))
-    expect(newPosition.quote).to.eql(new BigNumber('4900')) // 2% fee on $5000 = $100
+    expect(newPosition.base).to.eql(new BigNumber('0'))
+    expect(newPosition.quote).to.eql(new BigNumber('14900')) // 2% fee on $5000 = $100
   })
 })

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -15,6 +15,7 @@ import {
   calcLeverage,
   calcUnrealised,
   calcPositionAfterTrade,
+  calcFee
   // calcLiquidationPrice,
   // calcProfitableLiquidationPrice,
 } from "../src/Accounting"
@@ -320,5 +321,20 @@ describe('calcPositionAfterTrade', () => {
 
     expect(newPosition.base).to.eql(new BigNumber('0'))
     expect(newPosition.quote).to.eql(new BigNumber('14900')) // 2% fee on $5000 = $100
+  })
+})
+
+describe('calcFee', () => {
+  it('Calculates a 2% fee', () => {
+
+    const fee = calcFee(
+      new BigNumber('2'),
+      new BigNumber('5000'),
+      new BigNumber('0.02') // 2%
+    )
+
+    // 2 units at 5000 each = 10000
+    // 2% of 10000 = 200
+    expect(fee).to.eql(new BigNumber('200'))
   })
 })


### PR DESCRIPTION
# Motivation
- Add additional utils to be used by the executioner as part of https://mycelium-eth.atlassian.net/browse/LMDEVS-677

# Changes 
- add `calPositionAfterTrade` to accounting module
    - given a `position`, `trade` and `feeRate`, calculates the users position after performing the trade
- add `calcFee` to accounting module
    - given a `price`, `amount` and `feeRate`, calculates the total fee charged on the trade
- add test simple test cases to the new functions
- add `fromWad` util to accounting module
    - given a WAD number string, returns a normal BigNumber instance