### PR TITLE
[orders] add Orders module with calcOrderId

### DIFF
--- a/src/Orders/index.ts
+++ b/src/Orders/index.ts
@@ -1,0 +1,19 @@
+import { ethers } from 'ethers';
+import { OMEOrder } from '../Types/types';
+
+/**
+ * calculates the deterministic order id of an order
+ *
+ * @param order an OME serialised order
+ * @returns a string representation of the order id
+ */
+export const calcOrderId = (order: OMEOrder): string => {
+  const abiCoder = new ethers.utils.AbiCoder()
+
+  return ethers.utils.keccak256(
+    abiCoder.encode(
+      ["address", "address", "uint256", "uint256", "uint256", "uint256", "uint256"],
+      [order.user, order.target_tracer, order.price, order.amount, order.side === 'Bid' ? 0 : 1, order.expiration, order.created]
+    )
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from './Types/types';
 export * from './Accounting';
 export * from './Calculator';
 export * from './Insurance';
+export * from './Orders';


### PR DESCRIPTION
# Motivation
- The API needed to be able to calculate order ids

# Changes
- Added new `Orders` module with `calcOrderId` function