### PR TITLE
Return 0 not negative 1

### DIFF
--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -8,11 +8,12 @@ export const WAD_BASE = new BigNumber(10).pow(18)
 
 /**
  * Calculates the leverage multiplier the user currently has based on their position and a given price
- * @returns the leverage of the user at a given position or -1 if the position is invalid this represents infinite leverage
+ * @returns the leverage of the user at a given position 
+ * @returns 0 if the position is not leveraged or invalid
  */
 export const calcLeverage: (quote: BigNumber, base: BigNumber, price: BigNumber) => BigNumber = (quote, base, price) => {
     const margin = calcTotalMargin(quote, base, price);
-    if (margin.lte(0)) return new BigNumber(-1)
+    if (margin.lte(0)) return new BigNumber(0)
     return calcNotionalValue(base, price).div(margin)
 };
 

--- a/test/accountingTests.ts
+++ b/test/accountingTests.ts
@@ -211,13 +211,13 @@ describe.skip("Testing calcBorrowed", () => {
   })
 })
 
-describe.skip("Testing calcLeverage", () => {
+describe("Testing calcLeverage", () => {
   it('Basic Positions', () => {
     expect(calcLeverage(position1.quote, position1.base, position1.price), 'Position 1').to.be.bignumber.equal(5)
     expect(calcLeverage(position2.quote, position2.base, position2.price), 'Position 2').to.be.bignumber.equal(25)
   })
   it('Invalid Positions', () => {
-    expect(calcLeverage(invalid1.quote, invalid1.base, invalid1.price), 'Invalid 1').to.be.bignumber.equal(-1)
+    expect(calcLeverage(invalid1.quote, invalid1.base, invalid1.price), 'Invalid 1').to.be.bignumber.equal(0)
     expect(calcLeverage(invalid2.quote, invalid2.base, invalid2.price), 'Invalid 2').to.bignumber.equal(40)
   })
 })


### PR DESCRIPTION
# Motivation
Update calcLeverage function to avoid displaying -1. Orginally set to -1 as an errored state. But in reality did not provide any utility.

# Changes
- return 0 instead of -1
- re-add calcLeverage tests