### PR TITLE
[constants] add api codes

### DIFF
--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -1,4 +1,4 @@
-const API_CODES = {
+export const API_CODES = {
   INVALID_SIGNATURE: 'invalid_signature',
   UNDER_MARGIN: 'under_margin',
   INVALID_CREATED_TIMESTAMP: 'invalid_created_timestamp',
@@ -14,8 +14,4 @@ const API_CODES = {
   INVALID_TAKER: 'invalid_taker',
   MARKET_MISMATCH: 'market_mismatch',
   PRICE_NOT_CROSSED: 'price_not_crossed'
-}
-
-module.exports = {
-  API_CODES
 }

--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -13,5 +13,6 @@ export const API_CODES = {
   INVALID_MAKER: 'invalid_maker',
   INVALID_TAKER: 'invalid_taker',
   MARKET_MISMATCH: 'market_mismatch',
-  PRICE_NOT_CROSSED: 'price_not_crossed'
+  PRICE_NOT_CROSSED: 'price_not_crossed',
+  ORDERS_SAME_SIDE: 'orders_same_side'
 }

--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -7,7 +7,7 @@ export const API_CODES = {
   ORDER_PLACED: 'order_placed',
   ORDER_FULLY_MATCHED: 'order_fully_matched',
   ORDER_PARTIALLY_MATCHED: 'order_partially_matched',
-  CANCELLED: 'cancelled',
+  ORDER_CANCELLED: 'order_cancelled',
   BOOK_CREATED: 'book_created',
   BOOK_EXISTS: 'book_exists',
   INVALID_MAKER: 'invalid_maker',

--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -8,6 +8,7 @@ export const API_CODES = {
   ORDER_FULLY_MATCHED: 'order_fully_matched',
   ORDER_PARTIALLY_MATCHED: 'order_partially_matched',
   ORDER_CANCELLED: 'order_cancelled',
+  ORDER_EXISTS: 'order_exists',
   ORDER_NOT_FOUND: 'order_not_found',
   BOOK_NOT_FOUND: 'book_not_found',
   BOOK_CREATED: 'book_created',

--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -8,6 +8,8 @@ export const API_CODES = {
   ORDER_FULLY_MATCHED: 'order_fully_matched',
   ORDER_PARTIALLY_MATCHED: 'order_partially_matched',
   ORDER_CANCELLED: 'order_cancelled',
+  ORDER_NOT_FOUND: 'order_not_found',
+  BOOK_NOT_FOUND: 'book_not_found',
   BOOK_CREATED: 'book_created',
   BOOK_EXISTS: 'book_exists',
   INVALID_MAKER: 'invalid_maker',

--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -1,0 +1,21 @@
+const API_CODES = {
+  INVALID_SIGNATURE: 'invalid_signature',
+  UNDER_MARGIN: 'under_margin',
+  INVALID_CREATED_TIMESTAMP: 'invalid_created_timestamp',
+  INVALID_EXPIRY_TIMESTAMP: 'invalid_expiry_timestamp',
+  NOT_WHITELISTED: 'not_whitelisted',
+  ORDER_PLACED: 'order_placed',
+  ORDER_FULLY_MATCHED: 'order_fully_matched',
+  ORDER_PARTIALLY_MATCHED: 'order_partially_matched',
+  CANCELLED: 'cancelled',
+  BOOK_CREATED: 'book_created',
+  BOOK_EXISTS: 'book_exists',
+  INVALID_MAKER: 'invalid_maker',
+  INVALID_TAKER: 'invalid_taker',
+  MARKET_MISMATCH: 'market_mismatch',
+  PRICE_NOT_CROSSED: 'price_not_crossed'
+}
+
+module.exports = {
+  API_CODES
+}

--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -17,5 +17,6 @@ export const API_CODES = {
   INVALID_TAKER: 'invalid_taker',
   MARKET_MISMATCH: 'market_mismatch',
   PRICE_NOT_CROSSED: 'price_not_crossed',
-  ORDERS_SAME_SIDE: 'orders_same_side'
+  ORDERS_SAME_SIDE: 'orders_same_side',
+  OPERATION_FAILED: 'operation_failed'
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './Accounting';
 export * from './Calculator';
 export * from './Insurance';
 export * from './Orders';
+export * from './Constants';


### PR DESCRIPTION
# Motivation
- api codes should live in a central spot for re-use amongst the different repos

# Changes
- add `API_CODES` constants