### PR TITLE
[api codes] add INVALID_ADDRESS api code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/tracer-utils",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Helpful utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Constants/index.ts
+++ b/src/Constants/index.ts
@@ -18,5 +18,6 @@ export const API_CODES = {
   MARKET_MISMATCH: 'market_mismatch',
   PRICE_NOT_CROSSED: 'price_not_crossed',
   ORDERS_SAME_SIDE: 'orders_same_side',
-  OPERATION_FAILED: 'operation_failed'
+  OPERATION_FAILED: 'operation_failed',
+  INVALID_ADDRESS: 'invalid_address'
 }


### PR DESCRIPTION
# Motivation
- API needed a new code to send when a user tries to create a market with an invalid contract address

# Changes
- add `INVALID_ADDRESS` (`invalid_address`) api code 